### PR TITLE
fix: updating Dockerfile and Dockerfile.local to use mlp-base-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.9
-
-RUN pip install --upgrade pip poetry
+FROM 818831340115.dkr.ecr.us-east-1.amazonaws.com/python:3.9
 
 RUN mkdir -p /usr/share/fonts/truetype
 COPY fonts/* /usr/share/fonts/truetype/
 
 RUN fc-cache -fv
 
-RUN mkdir /code
-WORKDIR /code
 COPY . .
 
 ENV PYTHONPATH /code

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,14 +1,9 @@
-FROM python:3.9
-
-RUN pip install --upgrade pip poetry
+FROM 818831340115.dkr.ecr.us-east-1.amazonaws.com/python:3.9
 
 RUN mkdir -p /usr/share/fonts/truetype
 COPY fonts/* /usr/share/fonts/truetype/
 
 RUN fc-cache -fv
-
-RUN mkdir /code
-WORKDIR /code
 
 ADD pyproject.toml /code/
 ADD poetry.lock /code/


### PR DESCRIPTION
- modified:   Dockerfile
- modified:   Dockerfile.local
- requiring clarification if the following commands are required:

`RUN mkdir -p /usr/share/fonts/truetype`
- This commands create a directory for TrueType fonts and copy custom fonts into it. 

`COPY fonts/* /usr/share/fonts/truetype/:`
- This command builds the font cache. 